### PR TITLE
Reset timeouts on new match (#9) and related fixes

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -77,7 +77,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" media="(prefers-color-scheme: light)" content="white" />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { initialGame } from "@/lib/data";
 import { useGameStore } from "@/store";
 import { TeamNames } from "@/store/types";
 import Link from "next/link";
@@ -24,9 +23,13 @@ export default function Home() {
   };
 
   useEffect(() => {
-    if (match !== initialGame) {
+    const hasStartedGame =
+      match.homeTeamSetsWon > 0 ||
+      match.awayTeamSetsWon > 0 ||
+      Object.values(match.sets).some((set) => set.actions.length > 0);
+
+    if (hasStartedGame) {
       setExistingGame(true);
-      return;
     }
   }, [match]);
 

--- a/components/game/timeout/TimeoutButton.tsx
+++ b/components/game/timeout/TimeoutButton.tsx
@@ -21,6 +21,7 @@ const TimeoutButton = ({
   const handleTeamTimeout = useGameStore((state) => state.handleTeamTimeout);
   const [timeoutCountdown, setTimeoutCountdown] = useState<number>(0);
   const [play] = useSound("/sounds/buzzer.mp3");
+  const teamTimeoutCount = match.sets[currentSet].timeouts[team];
   useEffect(() => {
     let timeoutInterval;
     if (timeoutCountdown > 0) {
@@ -31,6 +32,14 @@ const TimeoutButton = ({
     }
     return () => clearInterval(timeoutInterval);
   }, [timeoutCountdown, play]);
+
+  // If the store's timeout count resets to 0 (e.g. game reset), cancel
+  // any running local countdown so the timer and buzzer stop.
+  useEffect(() => {
+    if (teamTimeoutCount === 0) {
+      setTimeoutCountdown(0);
+    }
+  }, [teamTimeoutCount]);
   return (
     <button
       className={`${
@@ -47,7 +56,7 @@ const TimeoutButton = ({
         handleTeamTimeout(team);
       }}
       disabled={
-        match.sets[currentSet].timeouts[team] >= 2 ||
+        teamTimeoutCount >= 2 ||
         timeoutCountdown > 0 ||
         gameComplete
       }

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,6 +1,6 @@
 import { Match, SetData } from "@/store/types";
 
-export const initialSetData: SetData = {
+export const createInitialSetData = (): SetData => ({
   setStartTime: new Date().toISOString(),
   score: {
     homeTeam: 0,
@@ -12,9 +12,9 @@ export const initialSetData: SetData = {
   },
   actions: [],
   winner: null,
-};
+});
 
-export const initialGame: Match = {
+export const createInitialGame = (): Match => ({
   homeTeamName: "Home",
   awayTeamName: "Away",
   firstServingTeam: null,
@@ -25,6 +25,6 @@ export const initialGame: Match = {
   timedGame: false,
   gameComplete: false,
   sets: {
-    1: { ...initialSetData },
+    1: createInitialSetData(),
   },
-};
+});

--- a/store/index.ts
+++ b/store/index.ts
@@ -1,4 +1,4 @@
-import { initialGame, initialSetData } from "@/lib/data";
+import { createInitialGame, createInitialSetData } from "@/lib/data";
 import { isSetComplete } from "@/utils";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
@@ -13,7 +13,7 @@ import {
 export const useGameStore = create<MatchStore>()(
   persist(
     (set, get) => ({
-      match: initialGame,
+      match: createInitialGame(),
       teamSwappedSides: false,
       currentSet: 1,
       servingTeam: null,
@@ -34,8 +34,8 @@ export const useGameStore = create<MatchStore>()(
       },
       startNewGame: (teamNames?: TeamNames) => {
         const newGame = teamNames
-          ? { ...initialGame, ...teamNames }
-          : { ...initialGame };
+          ? { ...createInitialGame(), ...teamNames }
+          : createInitialGame();
 
         set(() => ({
           match: newGame,
@@ -113,7 +113,7 @@ export const useGameStore = create<MatchStore>()(
       resetMatchData: () => {
         set((state) => ({
           match: {
-            ...initialGame,
+            ...createInitialGame(),
             homeTeamName: state.match.homeTeamName,
             awayTeamName: state.match.awayTeamName,
           },
@@ -244,7 +244,7 @@ export const useGameStore = create<MatchStore>()(
           return {
             match: {
               ...updatedMatch,
-              sets: { ...updatedMatch.sets, [newSetNumber]: initialSetData },
+              sets: { ...updatedMatch.sets, [newSetNumber]: createInitialSetData() },
             },
             currentSet: newSetNumber,
           };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary
Fixes #9 — timeout counts weren't resetting when a new match started — plus two related issues found while testing.

## Changes
- **Reset timeouts on new match (#9)** — `initialGame` / `initialSetData` were shared module-level objects being mutated in place, so a new match reused the old timeout counts (scores were fine because they updated immutably). Converted them to factory functions so every match and set gets a fresh, isolated copy.
- **Stop timeout countdown & buzzer on reset** — the countdown lived in local component state and kept ticking (buzzer included) after a game reset. Added an effect that cancels it when the store's timeout count resets to 0.
- **Suppress theme hydration warning** — added `suppressHydrationWarning` to the `<html>` element (the documented next-themes fix) to clear a pre-existing hydration mismatch.
- **chore** — commit the `jsx: preserve` change Next.js reapplies on every dev run.

Closes #9

The key line is Closes #9 — GitHub reads that and will auto-close issue #9 the moment this PR merges. That's the whole point of referencing the issue: the loop closes itself.